### PR TITLE
fix: prevent TypeError when planID is undefined on first login

### DIFF
--- a/src/hooks/use-plan.ts
+++ b/src/hooks/use-plan.ts
@@ -11,7 +11,7 @@ export function usePlan(): { userIsPro: boolean; isPlatform: boolean; userPlan: 
     }, [userInfo]);
 
     const userPlan = useMemo(() => {
-        if (userInfo.planID == '') return '';
+        if (!userInfo.planID || userInfo.planID == '') return '';
         if (userInfo.planID.startsWith('pro')) {
             return 'Pro';
         }


### PR DESCRIPTION
- Add null/undefined check for planID before calling startsWith()
- Fixes crash during first-time login when user info is still loading
- No breaking changes, defensive programming improvement